### PR TITLE
Catch keyboard interrupt

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ func main() {
 
 	_, result, err := prompt.Run()
 	if err != nil {
+		if err.Error() == "^C" {
+			return
+		}
 		fmt.Printf("Prompt failed %v\n", err)
 		return
 	}


### PR DESCRIPTION
I've been using this quit a bit and I like "clean quitting" on my tools so this is a small PR to add that.

SIGINT character (^C) during the prompt selection routine now quits without error. I think it's the easiest / smallest change I could make without passing an additional prompt.

